### PR TITLE
Single media in single album deselect crash fix

### DIFF
--- a/Source/Pages/Gallery/YPLibraryVC+CollectionView.swift
+++ b/Source/Pages/Gallery/YPLibraryVC+CollectionView.swift
@@ -68,8 +68,12 @@ extension YPLibraryVC {
 			
             // Replace the current selected image with the previously selected one
             if let previouslySelectedIndexPath = selectedIndexPaths.last {
-                v.collectionView.deselectItem(at: indexPath, animated: false)
-                v.collectionView.selectItem(at: previouslySelectedIndexPath, animated: false, scrollPosition: [])
+                if(v.collectionView.indexPathsForSelectedItems?.contains(indexPath) ?? false){
+                    v.collectionView.deselectItem(at: indexPath, animated: false)
+                }
+                if(v.collectionView.indexPathsForVisibleItems.contains(previouslySelectedIndexPath)){
+                    v.collectionView.selectItem(at: previouslySelectedIndexPath, animated: false, scrollPosition: [])
+                }
                 currentlySelectedIndex = previouslySelectedIndexPath.row
                 changeAsset(mediaManager.getAsset(at: previouslySelectedIndexPath.row))
             }


### PR DESCRIPTION
Steps to replicate crash:
1. Open image picker to select media from gallery
2. Select a few media items from an album consisting of multiple items
3. Change the album where there **is only 1 media**
4. First select and then deselect the item -> Crash

The fix:
Put in checks around select and deselect functions of collectionview to verify the presence of the indexpath at context.